### PR TITLE
Fixed new item delete issue

### DIFF
--- a/app/controllers/listContactsController.js
+++ b/app/controllers/listContactsController.js
@@ -2,10 +2,10 @@
 
 app.controller("listContactsController", function($scope, XHRCalls, AddressListService){
 
-  $scope.listAddress = function() {
-    AddressListService.clearAddressArray();
-    XHRCalls.xhrAddresses("", "get");
-    $scope.addressList = AddressListService.currentAddresses;
+  let listAddress = function() {
+      AddressListService.clearAddressArray();
+      XHRCalls.xhrAddresses("", "get");
+      $scope.addressList = AddressListService.currentAddresses;
   };
 
   $scope.deleteAddress = function(sentEvent) {
@@ -14,6 +14,6 @@ app.controller("listContactsController", function($scope, XHRCalls, AddressListS
     AddressListService.deleteAddressArrayItem(deleteItemID);
   };
 
-  $scope.listAddress();
+  listAddress();
 
 });

--- a/app/controllers/newEntryController.js
+++ b/app/controllers/newEntryController.js
@@ -40,7 +40,7 @@ app.controller("newEntryController", function($scope, $location, AddressListServ
     AddressListService.updateAddressArray($scope.newAddressObject);
     XHRCalls.xhrAddresses("", "post", $scope.newAddressObject);
     $scope.newAddressObject = "";
-    $location.path('/addresses/list');
+    $location.path('#/addresses/list');
   };
 
 });

--- a/app/factories/XHRCalls.js
+++ b/app/factories/XHRCalls.js
@@ -25,7 +25,7 @@ app.factory('XHRCalls', function($q, $http, AddressListService){
             resolve();
 
           } else if (xhrMethod === "post") {
-            sentData.id = returnedItem;
+            sentData.id = returnedItem.name;
             AddressListService.updateAddressArray(sentData);
             resolve();
           }


### PR DESCRIPTION
If a new item was added, it couldn't get deleted. The item can now be deleted as the wrong fb-id was being assigned.
